### PR TITLE
Removing debug_me calls

### DIFF
--- a/lib/debug_me/remove_debug_me_calls.rb
+++ b/lib/debug_me/remove_debug_me_calls.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+Synvert::Rewriter.new 'debug_me', 'remove_debug_me_calls' do
+  description <<~EOS
+    It removes `debug_me` calls.
+
+    debug_me  A tool to print the labeled value of variables.
+              |__ http://github.com/MadBomber/debug_me
+  EOS
+
+  within_files '**/*.rb' do
+    # removes debug_me methods
+    # removes all debug_me calls that have a block
+    with_node type: 'block', caller: { type: 'send', message: 'debug_me'} do
+      remove
+    end
+
+    # removes all debug_me calls that DO NOT have a block
+    with_node type: 'send', message: 'debug_me' do
+      remove
+    end
+  end
+end

--- a/lib/ruby/remove_debug_me_calls.rb
+++ b/lib/ruby/remove_debug_me_calls.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+Synvert::Rewriter.new 'ruby', 'remove_debug_me_calls' do
+  description <<~EOS
+    It removes `debug_me` calls.
+
+    debug_me  A tool to print the labeled value of variables.
+              |__ http://github.com/MadBomber/debug_me
+  EOS
+
+  within_files '**/*.rb' do
+    # removes debug_me methods
+    # removes all debug_me calls that have a block
+    with_node type: 'block', caller: { type: 'send', message: 'debug_me'} do
+      remove
+    end
+
+    # removes all debug_me calls that DO NOT have a block
+    with_node type: 'send', message: 'debug_me' do
+      remove
+    end
+  end
+end

--- a/spec/debug_me/remove_debug_me_calls_spec.rb
+++ b/spec/debug_me/remove_debug_me_calls_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Ruby removes debug_me calls' do
+  let(:rewriter_name) { 'debug_me/remove_debug_me_calls' }
+  let(:test_content) { <<~EOS }
+    def test
+      debug_me
+      debug_me('== HERE ==')
+      debug_me{}
+      debug_me{[ :hello, 'world' ]}
+      debug_me(tag: 'ERROR', levels: 5){[ :hello, :world ]}
+      #
+      DebugMe.debug_me
+      DebugMe.debug_me('== HERE ==')
+      DebugMe.debug_me{}
+      DebugMe.debug_me{[ :hello, 'world' ]}
+      DebugMe.debug_me(tag: 'ERROR', levels: 5){[ :hello, :world ]}
+    end
+  EOS
+
+  let(:test_rewritten_content) { <<~EOS }
+    def test
+      #
+    end
+  EOS
+
+  include_examples 'convertable'
+end

--- a/spec/ruby/remove_debug_me_calls_spec.rb
+++ b/spec/ruby/remove_debug_me_calls_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Ruby removes debug_me calls' do
+  let(:rewriter_name) { 'ruby/remove_debug_me_calls' }
+  let(:test_content) { <<~EOS }
+    def test
+      debug_me
+      debug_me('== HERE ==')
+      debug_me{}
+      debug_me{[ :hello, 'world' ]}
+      debug_me(tag: 'ERROR', levels: 5){[ :hello, :world ]}
+      #
+      DebugMe.debug_me
+      DebugMe.debug_me('== HERE ==')
+      DebugMe.debug_me{}
+      DebugMe.debug_me{[ :hello, 'world' ]}
+      DebugMe.debug_me(tag: 'ERROR', levels: 5){[ :hello, :world ]}
+    end
+  EOS
+
+  let(:test_rewritten_content) { <<~EOS }
+    def test
+      #
+    end
+  EOS
+
+  include_examples 'convertable'
+end


### PR DESCRIPTION
debug_me  A tool to print the labeled value of variables.
          |__ http://github.com/MadBomber/debug_me

Lets resolve not to keep debugging statement in a
production code base.  This is my gem.  I use it all
the time ... and yes, occassionally I have left debug_me
calls in my commits.  BUT NOW, with synvert I can
configure a pre-commit hook to remove those calls.