### PR TITLE
Auto corrected by following Lint Ruby UnusedArgument

### DIFF
--- a/lib/ruby/nested_class_definition.rb
+++ b/lib/ruby/nested_class_definition.rb
@@ -39,7 +39,7 @@ Synvert::Rewriter.new 'ruby', 'nested_class_definition' do
       class_name = parts.pop
       new_parts = parts.map.with_index { |mod, index| ' ' * NodeMutation.tab_width * index + "module #{mod}" }
       new_parts.concat(source.sub(parts.join('::') + '::', '').split("\n").map { |line| (' ' * NodeMutation.tab_width * parts.size) + line })
-      new_parts.concat(parts.map.with_index { |mod, index| ' ' * NodeMutation.tab_width * (parts.size - index - 1) + "end" })
+      new_parts.concat(parts.map.with_index { |_mod, index| ' ' * NodeMutation.tab_width * (parts.size - index - 1) + "end" })
 
       replace_with new_parts.join("\n")
     end


### PR DESCRIPTION
Auto corrected by following Lint Ruby UnusedArgument

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-snippets-ruby/config_groups/ruby/738) to configure it on awesomecode.io